### PR TITLE
Support Automattic AMP

### DIFF
--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -113,14 +113,15 @@ add_action( 'template_redirect', function() {
 
                                 // Automattic AMP
                                 if ( defined('AMP__DIR__') ) {
-                                    require_once AMP__DIR__ . '/includes/amp-helper-functions.php';
+                                    $amp_supported = AMP_Options_Manager::get_option('supported_post_types');
+                                    // Force ignnore page.
                                     if ($post_type !== 'page') {
-                                        echo var_dump($post);
-                                        echo "\n";
-                                        echo post_supports_amp($post);
-                                        echo "\n";
+                                        if (in_array($post_type, $amp_supported)) {
+                                            $amp_permalink =amp_get_permalink($post->ID);
+                                            $urls['items'][] = array('link_type' => 'amphtml', 'post_type' => $post_type, 'link' => $amp_permalink);
+                                        }
+                                        $url_count++;
                                     }
-                                    $url_count++;
                                 };
                                 if ($url_count >= $end_position)
                                     break;

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -107,9 +107,24 @@ add_action( 'template_redirect', function() {
                             } else {
                                 if ($url_count >= $start_position && $url_count < $end_position)
                                     $urls['items'][] = array('link_type' => 'permalink', 'post_type' => $post_type, 'link' => $permalink);
+                                    $url_count++;
                                 if ($url_count >= $end_position)
                                     break;
-                                $url_count++;
+
+                                // Automattic AMP
+                                if ( defined('AMP__DIR__') ) {
+                                    require_once AMP__DIR__ . '/includes/amp-helper-functions.php';
+                                    if ($post_type !== 'page') {
+                                        echo var_dump($post);
+                                        echo "\n";
+                                        echo post_supports_amp($post);
+                                        echo "\n";
+                                    }
+                                    $url_count++;
+                                };
+                                if ($url_count >= $end_position)
+                                    break;
+
                             }
                         }
                     }

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -116,16 +116,18 @@ add_action( 'template_redirect', function() {
                                     $amp_supported = AMP_Options_Manager::get_option('supported_post_types');
                                     // Force ignnore page.
                                     if ($post_type !== 'page') {
-                                        if (in_array($post_type, $amp_supported)) {
-                                            $amp_permalink =amp_get_permalink($post->ID);
-                                            if ($url_count >= $start_position && $url_count < $end_position)
-                                                $urls['items'][] = array('link_type' => 'amphtml', 'post_type' => $post_type, 'link' => $amp_permalink);
-                                            if ($url_count >= $end_position)
-                                                break;
-                                            $url_count++;
+                                        if (in_array($post_type, (array)$amp_supported)) {
+                                            if (post_supports_amp($post)) {
+                                                $amp_permalink =amp_get_permalink($post->ID);
+                                                if ($url_count >= $start_position && $url_count < $end_position)
+                                                    $urls['items'][] = array('link_type' => 'amphtml', 'post_type' => $post_type, 'link' => $amp_permalink);
+                                                if ($url_count >= $end_position)
+                                                    break;
+                                                $url_count++;
+                                            }
                                         }
                                     }
-                                };
+                                }
                             }
                         }
                     }

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -113,7 +113,12 @@ add_action( 'template_redirect', function() {
 
                                 // Automattic AMP
                                 if ( defined('AMP__DIR__') ) {
-                                    $amp_supported = AMP_Options_Manager::get_option('supported_post_types');
+                                    // supported_post_types is empty until first saved the setting.
+                                    if (AMP_Options_Manager::get_option('supported_post_types')) {
+                                        $amp_supported = AMP_Options_Manager::get_option('supported_post_types');
+                                    } else {
+                                        $amp_supported = array("post");
+                                    }
                                     // Force ignnore page.
                                     if ($post_type !== 'page') {
                                         if (in_array($post_type, (array)$amp_supported)) {

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -105,9 +105,10 @@ add_action( 'template_redirect', function() {
                                     die();
                                 }
                             } else {
-                                if ($url_count >= $start_position && $url_count < $end_position)
+                                if ($url_count >= $start_position && $url_count < $end_position) {
                                     $urls['items'][] = array('link_type' => 'permalink', 'post_type' => $post_type, 'link' => $permalink);
                                     $url_count++;
+                                }
                                 if ($url_count >= $end_position)
                                     break;
 
@@ -125,7 +126,6 @@ add_action( 'template_redirect', function() {
                                 };
                                 if ($url_count >= $end_position)
                                     break;
-
                             }
                         }
                     }

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -111,8 +111,8 @@ add_action( 'template_redirect', function() {
                                     break;
                                 $url_count++;
 
-                                // Automattic AMP
-                                if ( defined('AMP__DIR__') ) {
+                                // Detect Automattic AMP
+                                if ( function_exists( 'amp_get_permalink' ) ) {
                                     // supported_post_types is empty until first saved the setting.
                                     if (AMP_Options_Manager::get_option('supported_post_types')) {
                                         $amp_supported = AMP_Options_Manager::get_option('supported_post_types');

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -119,8 +119,8 @@ add_action( 'template_redirect', function() {
                                         if (in_array($post_type, $amp_supported)) {
                                             $amp_permalink =amp_get_permalink($post->ID);
                                             $urls['items'][] = array('link_type' => 'amphtml', 'post_type' => $post_type, 'link' => $amp_permalink);
+                                            $url_count++;
                                         }
-                                        $url_count++;
                                     }
                                 };
                                 if ($url_count >= $end_position)

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -105,12 +105,11 @@ add_action( 'template_redirect', function() {
                                     die();
                                 }
                             } else {
-                                if ($url_count >= $start_position && $url_count < $end_position) {
+                                if ($url_count >= $start_position && $url_count < $end_position)
                                     $urls['items'][] = array('link_type' => 'permalink', 'post_type' => $post_type, 'link' => $permalink);
-                                    $url_count++;
-                                }
                                 if ($url_count >= $end_position)
                                     break;
+                                $url_count++;
 
                                 // Automattic AMP
                                 if ( defined('AMP__DIR__') ) {
@@ -119,13 +118,14 @@ add_action( 'template_redirect', function() {
                                     if ($post_type !== 'page') {
                                         if (in_array($post_type, $amp_supported)) {
                                             $amp_permalink =amp_get_permalink($post->ID);
-                                            $urls['items'][] = array('link_type' => 'amphtml', 'post_type' => $post_type, 'link' => $amp_permalink);
+                                            if ($url_count >= $start_position && $url_count < $end_position)
+                                                $urls['items'][] = array('link_type' => 'amphtml', 'post_type' => $post_type, 'link' => $amp_permalink);
+                                            if ($url_count >= $end_position)
+                                                break;
                                             $url_count++;
                                         }
                                     }
                                 };
-                                if ($url_count >= $end_position)
-                                    break;
                             }
                         }
                     }


### PR DESCRIPTION
AMPプラグインがActiveであれば、ampをgenerate対象にふくめます。


- [x] 投稿ごとにAMPにするかどうかを選択できる
- [x] supported_post_types は一度も設定をセーブしていなければ空っぽ。