### PR TITLE
Added disables parameter

### DIFF
--- a/include/class-shifter-urls.php
+++ b/include/class-shifter-urls.php
@@ -363,38 +363,49 @@ class ShifterUrls
     private function _get_urls_all()
     {
         $urls = $this->_default_urls_array();
+
+        // top page & feed links
         if (!$this->_check_skip('top')) {
-            $this->_top_page_urls($urls);            // top page & feed links
-        }
-        // Front pagenate links
-        if (!($this->_check_skip('top_pagenate') || $this->_check_skip('top'))) {
-            query_posts('');
-            if ('posts' === get_option('show_on_front')) {
-                $this->_pagenate_urls($urls);
-            } else {
-                $this->_pagenate_urls_page_on_front($urls);
-                $this->_pagenate_urls_page_for_posts($urls);
+            $this->_top_page_urls($urls);
+            // Front pagenate links
+            if (!$this->_check_skip('top_pagenate')) {
+                query_posts('');
+                if ('posts' === get_option('show_on_front')) {
+                    $this->_pagenate_urls($urls);
+                } else {
+                    $this->_pagenate_urls_page_on_front($urls);
+                    $this->_pagenate_urls_page_for_posts($urls);
+                }
+                wp_reset_query();
             }
-            wp_reset_query();
         }
+
+        // posts links
         if (!$this->_check_skip('singular')) {
-            $this->_posts_urls($urls);               // posts links
+            $this->_posts_urls($urls);
         }
-        if (!($this->_check_skip('post_archive') || $this->_check_skip('archive'))) {
-            $this->_post_type_archive_urls($urls);   // archive links
+
+        // archive links
+        if (!$this->_check_skip('archive')) {
+            if (!$this->_check_skip('post_archive')) {
+                $this->_post_type_archive_urls($urls);   // archive links
+            }
+            if (!$this->_check_skip('term_archive')) {
+                $this->_post_type_term_urls($urls);      // term links
+            }
+            if (!$this->_check_skip('date_archive')) {
+                $this->_archive_urls($urls);             // date archives
+            }
+            if (!$this->_check_skip('author_archive')) {
+                $this->_authors_urls($urls);             // authors link
+            }
         }
-        if (!($this->_check_skip('term_archive') || $this->_check_skip('archive'))) {
-            $this->_post_type_term_urls($urls);      // term links
-        }
-        if (!($this->_check_skip('date_archive') || $this->_check_skip('archive'))) {
-            $this->_archive_urls($urls);             // date archives
-        }
-        if (!$this->_check_skip('author')) {
-            $this->_authors_urls($urls);             // authors link
-        }
+
+        // redirection links
         if (!$this->_check_skip('redirection')) {
-            $this->_redirection_urls($urls);         // redirection link
+            $this->_redirection_urls($urls);
         }
+
         $urls['request_type'] = self::URL_TOP;
         $urls['request_path'] = $this->get_request_path();
         $urls['count'] = count($urls['items']);

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -3,7 +3,7 @@
 Plugin Name: Shifter – Artifact Helper
 Plugin URI: https://github.com/getshifter/shifter-artifact-helper
 Description: Helper tool for building Shifter Artifacts
-Version: 1.0.0
+Version: 1.0.1
 Author: Shifter Team
 Author URI: https://getshifter.io
 License: GPLv2 or later
@@ -71,7 +71,7 @@ function shifter_urls_for_rest_api($data=[])
         define('SHIFTER_REST_REQUEST', true);
     }
 
-    $request_path = '/' . (isset($data['path']) && !empty($data['path']) ? $data['path'] : '');
+    $request_path = trailingslashit('/' . (isset($data['path']) && !empty($data['path']) ? $data['path'] : ''));
     $json_data = shifter_get_urls($request_path, true);
     $json_data['page']++;
 


### PR DESCRIPTION
disables というクエリストリングで一時的に抽出しないURLを指定することができるようにしました。(デバッグ用)
指定できるのは以下の通り

- top ( top_pagenate 含む )
- top_pagenate
- archive ( post_archive, term_archive, date_archive, author_archive 全てを含む )
- post_archive
- term_archive
- date_archive
- author_archive
- singular ( attachment, amp 含む )
- attachment
- amp
- feed
- redirection

複数指定するときはカンマ区切りで指定します。
以下は全て対象外にするときの例

```
curl -s 'https://127.0.0.1:8443/?urls=0&disables=top,archive,author,singular,feed,redirection' | jq .
curl -s 'https://127.0.0.1:8443/wp-json/shifter/v1/urls/?disables=top,archive,author,singular,feed,redirection' | jq .
```