### PR TITLE
fixed get_permalink bug

### DIFF
--- a/include/class-shifter-urls-base.php
+++ b/include/class-shifter-urls-base.php
@@ -747,6 +747,7 @@ class ShifterUrlsBase
                 : amp_get_permalink($post_id);
             $this->_set_transient($key, $permalink);
         }
+        $permalink = preg_replace('/#[^#]*$/', '', $permalink);
         return $permalink;
     }
 

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -3,7 +3,7 @@
 Plugin Name: Shifter – Artifact Helper
 Plugin URI: https://github.com/getshifter/shifter-artifact-helper
 Description: Helper tool for building Shifter Artifacts
-Version: 1.1.0
+Version: 1.1.1
 Author: Shifter Team
 Author URI: https://getshifter.io
 License: GPLv2 or later


### PR DESCRIPTION
WP のどのバージョンからかわからないけど attachment の permalink を get_permalink() で取得すると、URL の最後に `#main` が着くようになっていました。
これが、原因で attachment より後の Custom Post の URL 取得がスキップされていたので、それを修正するための fix です。