### PR TITLE
Support Polylang Pro

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -30,6 +30,9 @@ function shifter_get_urls($request_path = null, $rest_request = false)
             if (is_plugin_active('polylang/polylang.php') && function_exists('pll_default_language')) {
                 return true;
             }
+            if (is_plugin_active('polylang-pro/polylang.php') && function_exists('pll_default_language')) {
+                return true;
+            }
         }
 
         return false;

--- a/shifter-artifact-helper.php
+++ b/shifter-artifact-helper.php
@@ -3,7 +3,7 @@
 Plugin Name: Shifter – Artifact Helper
 Plugin URI: https://github.com/getshifter/shifter-artifact-helper
 Description: Helper tool for building Shifter Artifacts
-Version: 1.5.0
+Version: 1.5.1
 Author: Shifter Team
 Author URI: https://getshifter.io
 License: GPLv2 or later


### PR DESCRIPTION
Polylang Pro が有効だった場合、ShifterUrlsPolylang クラスが読み込まれていなかったため修正