### PR TITLE
Update function name to resolve conflict

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -23,7 +23,7 @@ function shifter_get_urls($request_path = null, $rest_request = false)
      * Check Polylang status
      * @return boolean
      */
-    function is_polylang_active()
+    function shifter_is_polylang_active()
     {
         if (defined('POLYLANG_BASENAME') || defined('POLYLANG_PRO')) {
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -38,7 +38,7 @@ function shifter_get_urls($request_path = null, $rest_request = false)
         return false;
     }
 
-    if (is_polylang_active()) {
+    if (shifter_is_polylang_active()) {
         // function_exists('pll_default_language')) returns true via rest-api
         // pll_default_language() returns false without any settings
         if (pll_default_language()) {


### PR DESCRIPTION
@wokamoto It appears that there is a conflict with the function name for is_polylang_active(). I've updated the function name with the Shifter prefix to resolve the erorr. We should consider revising this plugin to use namespaces in a future release. 🍻 

Let me know if this works for you.