### PR TITLE
Append filter hook (ShifterURLS::CheckURL)

### DIFF
--- a/include/class-shifter-urls-base.php
+++ b/include/class-shifter-urls-base.php
@@ -32,6 +32,8 @@ class ShifterUrlsBase
     const FILTER_ADD_URL_NAME = 'ShifterURLS::AppendURLtoAll';
     const FILTER_ADD_SINGLEPAGE_URL_NAME = 'ShifterURLS::AppendURLtoSinglePage';
 
+    const FILTER_CHECK_URL_NAME = 'ShifterURLS::CheckURL';
+
     /**
      * Constructor
      */
@@ -549,13 +551,14 @@ class ShifterUrlsBase
      */
     private function _check_link_format($link)
     {
+        $correct = true;
         if (!$link || trailingslashit($link) === trailingslashit($this->get('home_url'))) {
-            return false;
+            $correct = false;
         }
         if (!preg_match('#/$#', $link)) {
-            return false;
+            $correct = false;
         }
-        return true;
+        return apply_filters(self::FILTER_CHECK_URL_NAME, $correct, $link);
     }
 
     /**


### PR DESCRIPTION
このPRを取り込むことで以下のようなフィルターフックを追加できます。

```
add_filter( 'ShifterURLS::CheckURL', function ($correct_link, $link) {
    // /archive/ が含まれるURLは generate 対象外にする
    if ( preg_match( '#/archive/#', $link ) ) {
        $correct_link = false;
    }
    return $correct_link;
}, 10, 2);
```

除外したいURLを指定したい場合などに利用できます。