### PR TITLE
Unify skip term archives logic and fix taxonomy skip checks

### DIFF
--- a/include/class-shifter-urls-base.php
+++ b/include/class-shifter-urls-base.php
@@ -337,7 +337,7 @@ class ShifterUrlsBase
             if (!$this->_check_skip('post_archive')) {
                 $this->_post_type_archive_urls($urls);   // archive links
             }
-            if (!$this->_check_skip('term_archive')) {
+            if (!$this->_check_skip('terms')) {
                 $this->_post_type_term_urls($urls);      // term links
             }
             if (!$this->_check_skip('date_archive')) {

--- a/include/class-shifter-urls-base.php
+++ b/include/class-shifter-urls-base.php
@@ -1102,6 +1102,18 @@ class ShifterUrlsBase
         return get_object_taxonomies($post_type);
     }
 
+    /**
+     * Resolve skip option key from taxonomy name.
+     *
+     * @param string $taxonomy_name
+     *
+     * @return string
+     */
+    protected function _get_skip_key_from_taxonomy($taxonomy_name)
+    {
+        return preg_replace('/^post_/', '', $taxonomy_name);
+    }
+
     protected function _get_terms($taxonomy_name, $arg='')
     {
         return get_terms($taxonomy_name, $arg);
@@ -1193,7 +1205,7 @@ class ShifterUrlsBase
                 $this->_set_transient($key, $taxonomy_names);
             }
             foreach ($taxonomy_names as $taxonomy_name) {
-                if ($this->_check_skip(str_replace($post_type.'_', '', $taxonomy_name))) {
+                if ($this->_check_skip($this->_get_skip_key_from_taxonomy($taxonomy_name))) {
                     continue;
                 }
                 $key = __METHOD__."-{$post_type}-{$taxonomy_name}";


### PR DESCRIPTION
## 概要
タクソノミーのスキップ判定まわりの不具合を修正しました。

## 変更内容
1. **Bug 1: タグ漏れ修正**
   - `_post_type_term_urls()` の skip 判定を、`post_type` 依存の置換から見直し
   - タクソノミー名ベースで `post_` プレフィックスを除去して判定するように変更
   - `post_tag` が他 post type に紐づく場合でも `shifter_skip_tag` が正しく効くように修正

2. **Bug 2: Skip term archives 不具合修正**
   - `term_archive` ではなく `terms` を参照するように統一
   - `admin.php` の `shifter_skip_terms` 設定と判定キーを一致させた

## 互換性について
- `term_archive` 互換は入れていません（`admin.php` にも存在せず、`terms` に統一）。

## 確認内容
- `php -l include/class-shifter-urls-base.php` 通過
- 統合テスト: `integration_test/entry.rb` 実行済み（94 tests, 0 failures）
- 手動確認:
  - `Skip tag archives` で `/tag/*` の出力抑制を確認
  - `Skip term archives` で term 系 URL の抑制を確認